### PR TITLE
Support qq 6.6.6

### DIFF
--- a/app/src/main/java/me/veryyoung/qq/luckymoney/Main.java
+++ b/app/src/main/java/me/veryyoung/qq/luckymoney/Main.java
@@ -87,7 +87,7 @@ public class Main implements IXposedHookLoadPackage {
                         requestUrl.append("&groupid=" + (istroop == 0 ? selfuin : frienduin));
                         requestUrl.append("&grouptype=" + getGroupType());
                         requestUrl.append("&groupuin=" + getGroupuin(messageType));
-                        requestUrl.append("&channel=" + getObjectField(mQQWalletRedPacketMsg, "redChannel"));
+                        requestUrl.append("&channel=" + getObjectField(mQQWalletRedPacketMsg, "channelId"));
                         requestUrl.append("&authkey=" + authkey);
                         requestUrl.append("&agreement=0");
 

--- a/app/src/main/java/me/veryyoung/qq/luckymoney/VersionParam.java
+++ b/app/src/main/java/me/veryyoung/qq/luckymoney/VersionParam.java
@@ -24,6 +24,7 @@ public class VersionParam {
             case "6.6.1":
             case "6.6.2":
             case "6.6.5":
+            case "6.6.6":
                 QQPluginClass = "com.tenpay.android.qqplugin.a.q";
                 break;
             default:


### PR DESCRIPTION
QQWalletRedPacketMsg类成员redChannel改名成channelId了，之前的不能用了。
测试6.6.2和6.6.6通过。

com.tencent.mobileqq:tool I/Xposed: Found QQ version:6.6.2
com.tencent.mobileqq E/Xposed: java.lang.NoSuchFieldError: com.tencent.mobileqq.data.QQWalletRedPacketMsg#redChannel
                                                                at de.robv.android.xposed.XposedHelpers.findField(XposedHelpers.java:113)
                                                                at de.robv.android.xposed.XposedHelpers.getObjectField(XposedHelpers.java:848)
                                                                at me.veryyoung.qq.luckymoney.Main$1.afterHookedMethod(Main.java:90)
                                                                at de.robv.android.xposed.XposedBridge.handleHookedMethod(XposedBridge.java:348)
                                                                at com.tencent.mobileqq.data.MessageForQQWalletMsg.doParse(<Xposed>)
                                                                at com.tencent.mobileqq.data.ChatMessage.parse(ProGuard:64)
                                                                at com.tencent.mobileqq.app.message.BaseMessageManager.a(ProGuard:1198)
                                                                at com.tencent.mobileqq.app.message.QQMessageFacade.a(ProGuard:1735)
                                                                at com.tencent.mobileqq.app.message.QQMessageFacade.a(ProGuard:959)
                                                                at com.tencent.mobileqq.app.message.QQMessageFacade.a(ProGuard:789)
                                                                at com.tencent.mobileqq.troop.data.TroopMessageProcessor.a(ProGuard:859)
                                                                at com.tencent.mobileqq.troop.data.TroopMessageProcessor.a(ProGuard:109)
                                                                at com.tencent.mobileqq.app.MessageHandler.h(ProGuard:2398)
                                                                at com.tencent.mobileqq.app.MessageHandler.a(ProGuard:3851)
                                                                at com.tencent.mobileqq.service.MobileQQServiceBase.a(ProGuard:309)
                                                                at com.tencent.mobileqq.service.MobileQQService.a(ProGuard:658)
                                                                at com.tencent.mobileqq.app.QQAppInterface.a(ProGuard:8998)
                                                                at com.tencent.mobileqq.compatible.TempServlet.onReceive(ProGuard:52)
                                                                at mqq.app.MSFServlet.onReceive(MSFServlet.java:39)
                                                                at mqq.app.ServletContainer.notifyMSFServlet(ServletContainer.java:125)
                                                                at mqq.app.MainService.receiveMessageFromMSF(MainService.java:261)
                                                                at mqq.app.MainService.access$300(MainService.java:67)
                                                                at mqq.app.MainService$5.onRecvCmdPush(MainService.java:830)
                                                                at com.tencent.mobileqq.msf.sdk.MsfRespHandleUtil.handlePushMsg(MsfRespHandleUtil.java:186)
                                                                at mqq.app.MainService$2.run(MainService.java:459)
                                                                at java.lang.Thread.run(Thread.java:818)
